### PR TITLE
Disable operator& overload safeguard [SAR-261]

### DIFF
--- a/optional.hpp
+++ b/optional.hpp
@@ -356,7 +356,11 @@ class optional : private OptionalBase<T>
 
   constexpr bool initialized() const noexcept { return OptionalBase<T>::init_; }
   typename std::remove_const<T>::type* dataptr() {  return std::addressof(OptionalBase<T>::storage_.value_); }
+#ifdef OPTIONAL_CONDITIONAL_REF
   constexpr const T* dataptr() const { return detail_::static_addressof(OptionalBase<T>::storage_.value_); }
+#else
+  const T* dataptr() const { return std::addressof(OptionalBase<T>::storage_.value_); }
+#endif
   
 # if OPTIONAL_HAS_THIS_RVALUE_REFS == 1
   constexpr const T& contained_val() const& { return OptionalBase<T>::storage_.value_; }

--- a/optional.hpp
+++ b/optional.hpp
@@ -617,7 +617,7 @@ public:
   
   constexpr optional(nullopt_t) noexcept : ref(nullptr) {}
    
-  constexpr optional(T& v) noexcept : ref(detail_::static_addressof(v)) {}
+  constexpr optional(T& v) noexcept : ref(&v) {}
   
   optional(T&&) = delete;
   

--- a/optional.hpp
+++ b/optional.hpp
@@ -616,9 +616,13 @@ public:
   constexpr optional() noexcept : ref(nullptr) {}
   
   constexpr optional(nullopt_t) noexcept : ref(nullptr) {}
-   
-  constexpr optional(T& v) noexcept : ref(&v) {}
-  
+
+#ifdef OPTIONAL_CONDITIONAL_REF
+  constexpr optional(T& v) noexcept : ref(detail_::static_addressof(v)) {}
+#else
+  optional(T& v) noexcept : ref(std::addressof(v)) {}
+#endif
+
   optional(T&&) = delete;
   
   constexpr optional(const optional& rhs) noexcept : ref(rhs.ref) {}

--- a/test_optional.cpp
+++ b/test_optional.cpp
@@ -1193,7 +1193,6 @@ TEST(arrow_operator)
   assert (on->n == 2);
 };
 
-#ifdef OPTIONAL_CONDITIONAL_REF
 TEST(arrow_wit_optional_ref)
 {
   using namespace std::experimental;
@@ -1228,7 +1227,6 @@ TEST(arrow_wit_optional_ref)
   assert (om->m == 1);
   assert (om->n == 2);
 };
-#endif
 
 TEST(no_dangling_reference_in_value)
 {

--- a/test_optional.cpp
+++ b/test_optional.cpp
@@ -1193,40 +1193,43 @@ TEST(arrow_operator)
   assert (on->n == 2);
 };
 
-TEST(arrow_wit_optional_ref)
-{
-  using namespace std::experimental;
-  
-  Combined c{1, 2};
-  optional<Combined&> oc = c;
-  assert (oc);
-  assert (oc->m == 1);
-  assert (oc->n == 2);
-  
-  Nasty n{1, 2};
-  Nasty m{3, 4};
-  Nasty p{5, 6};
-  
-  optional<Nasty&> on{n};
-  assert (on);
-  assert (on->m == 1);
-  assert (on->n == 2);
-  
-  on = {m};
-  assert (on);
-  assert (on->m == 3);
-  assert (on->n == 4);
-  
-  on.emplace(p);
-  assert (on);
-  assert (on->m == 5);
-  assert (on->n == 6);
-  
-  optional<Nasty&> om{in_place, n};
-  assert (om);
-  assert (om->m == 1);
-  assert (om->n == 2);
-};
+// This test was commented out because support for the feature: "make operator->
+// conditionally constexpr based on whether T::operator& is overloaded" was
+// disabled.
+//TEST(arrow_wit_optional_ref)
+//{
+//  using namespace std::experimental;
+//
+//  Combined c{1, 2};
+//  optional<Combined&> oc = c;
+//  assert (oc);
+//  assert (oc->m == 1);
+//  assert (oc->n == 2);
+//
+//  Nasty n{1, 2};
+//  Nasty m{3, 4};
+//  Nasty p{5, 6};
+//
+//  optional<Nasty&> on{n};
+//  assert (on);
+//  assert (on->m == 1);
+//  assert (on->n == 2);
+//
+//  on = {m};
+//  assert (on);
+//  assert (on->m == 3);
+//  assert (on->n == 4);
+//
+//  on.emplace(p);
+//  assert (on);
+//  assert (on->m == 5);
+//  assert (on->n == 6);
+//
+//  optional<Nasty&> om{in_place, n};
+//  assert (om);
+//  assert (om->m == 1);
+//  assert (om->n == 2);
+//};
 
 TEST(no_dangling_reference_in_value)
 {

--- a/test_optional.cpp
+++ b/test_optional.cpp
@@ -1193,43 +1193,42 @@ TEST(arrow_operator)
   assert (on->n == 2);
 };
 
-// This test was commented out because support for the feature: "make operator->
-// conditionally constexpr based on whether T::operator& is overloaded" was
-// disabled.
-//TEST(arrow_wit_optional_ref)
-//{
-//  using namespace std::experimental;
-//
-//  Combined c{1, 2};
-//  optional<Combined&> oc = c;
-//  assert (oc);
-//  assert (oc->m == 1);
-//  assert (oc->n == 2);
-//
-//  Nasty n{1, 2};
-//  Nasty m{3, 4};
-//  Nasty p{5, 6};
-//
-//  optional<Nasty&> on{n};
-//  assert (on);
-//  assert (on->m == 1);
-//  assert (on->n == 2);
-//
-//  on = {m};
-//  assert (on);
-//  assert (on->m == 3);
-//  assert (on->n == 4);
-//
-//  on.emplace(p);
-//  assert (on);
-//  assert (on->m == 5);
-//  assert (on->n == 6);
-//
-//  optional<Nasty&> om{in_place, n};
-//  assert (om);
-//  assert (om->m == 1);
-//  assert (om->n == 2);
-//};
+#ifdef OPTIONAL_CONDITIONAL_REF
+TEST(arrow_wit_optional_ref)
+{
+  using namespace std::experimental;
+
+  Combined c{1, 2};
+  optional<Combined&> oc = c;
+  assert (oc);
+  assert (oc->m == 1);
+  assert (oc->n == 2);
+
+  Nasty n{1, 2};
+  Nasty m{3, 4};
+  Nasty p{5, 6};
+
+  optional<Nasty&> on{n};
+  assert (on);
+  assert (on->m == 1);
+  assert (on->n == 2);
+
+  on = {m};
+  assert (on);
+  assert (on->m == 3);
+  assert (on->n == 4);
+
+  on.emplace(p);
+  assert (on);
+  assert (on->m == 5);
+  assert (on->n == 6);
+
+  optional<Nasty&> om{in_place, n};
+  assert (om);
+  assert (om->m == 1);
+  assert (om->n == 2);
+};
+#endif
 
 TEST(no_dangling_reference_in_value)
 {
@@ -1324,6 +1323,7 @@ TEST(three_ways_of_having_value)
   assert (bool(r1) == r1.has_value());
 };
 
+# ifdef OPTIONAL_CONDITIONAL_REF
 //// constexpr tests
 
 // these 4 classes have different noexcept signatures in move operations
@@ -1480,6 +1480,7 @@ namespace InitList
 #endif // OPTIONAL_HAS_CONSTEXPR_INIT_LIST
 
 // end constexpr tests
+#endif
 
 
 #include <string>


### PR DESCRIPTION
Optional has a feature that conditionally resolves the address of an object when that object's class has the `operator&` overloaded to something else. That declaration can be found [here](https://github.com/swift-nav/Optional/blob/b00949aea64594115b67798ab9ad1f4dc5458cb9/optional.hpp#L222) and [here](https://github.com/swift-nav/Optional/blob/b00949aea64594115b67798ab9ad1f4dc5458cb9/optional.hpp#L228).

When running the static analysis tool, Helix expects to find a constant type in the argument templates. But the macro `TR2_OPTIONAL_REQUIRES` isn't being properly resolved by the static analysis tool. That macro is defined [here](https://github.com/swift-nav/Optional/blob/b00949aea64594115b67798ab9ad1f4dc5458cb9/optional.hpp#L21).

So we end up in the following situation. Either we suppress the warning in Helix (there is one being generated for each file that includes optional and instantiates it, 274 currently) or we remove this feature that isn't compliant with Helix.

This PR also comments out the testing of that feature. All the other tests still work. Compiling starling and running all the unit tests also works.