### PR TITLE
Change CMake Target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,10 @@
 cmake_minimum_required(VERSION 2.8)
 project(optional)
 
-add_library(optional INTERFACE)
-target_include_directories(optional
+add_library(akrzemi1_optional INTERFACE)
+add_library(optional ALIAS akrzemi1_optional)
+add_library(akrzemi1::optional ALIAS akrzemi1_optional)
+target_include_directories(akrzemi1_optional
     INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
     )
 


### PR DESCRIPTION
This project defines a cmake build target `optional`. This is quite a common name, colliding with, for example abseil::optional.

This prefixes the target name and adds an alias target to that clients can be updated gradually.

Eventually the alias will be dropped when all clients have been moved to using the new target.

The motivation for this change is that a couple of our dependencies (namely protobuf & gRPC), now include abseil as a dependency which defines its own `optional` target. We'll have to patch this collision before we're able to update to newer versions of these libraries.

Also see: (https://github.com/swift-nav/cmake/pull/110)